### PR TITLE
[CO-4142] Adapt rsyslog image - Initial Release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM bluescape/base-centos7
 
 ENV PID_DIR /tmp/pidDir
 
@@ -15,4 +15,8 @@ COPY rsyslog.conf /etc/rsyslog.conf
 EXPOSE 1514
 
 CMD ["sh", "-c", "/usr/sbin/rsyslogd -i ${PID_DIR}/pid -n"]
+
+LABEL \
+  org.label-schema.name="rsyslof" \
+  org.label-schema.description="Bluescape rsyslog endpoint"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ EXPOSE 1514
 CMD ["sh", "-c", "/usr/sbin/rsyslogd -i ${PID_DIR}/pid -n"]
 
 LABEL \
-  org.label-schema.name="rsyslof" \
-  org.label-schema.description="Bluescape rsyslog endpoint"
+  org.label-schema.name="rsyslog" \
+  org.label-schema.description="Bluescape rsyslog"
 

--- a/rsyslog-server-oscp-template.json
+++ b/rsyslog-server-oscp-template.json
@@ -46,7 +46,7 @@
                         "containers": [
                             {
                                 "name": "rsyslog",
-                                "image": "docker.io/philipgough/rsyslog",
+                                "image": "dummy",
                                 "ports": [
                                     {
                                         "name": "rsyslog-udp",


### PR DESCRIPTION
* Use `bluescape/base-centos7` instead of generic `centos7` as a base image.
* Remove `docker-io` image from the template. This file will be deprecated once this is moved to `openshift-resources` repository.