### PR TITLE
[CO-4344] Custom msg format for capturing logs

### DIFF
--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -15,7 +15,8 @@ $InputTCPServerRun 1514
 $WorkDirectory /var/lib/rsyslog
 
 # Use default timestamp format
-$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+$template msgOnlyFormat,"%msg%\n"
+$ActionFileDefaultTemplate msgOnlyFormat
 
 
 # Include all config files in /etc/rsyslog.d/

--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -28,7 +28,7 @@ $IncludeConfig /etc/rsyslog.d/*.conf
 #### RULES ####
 
 # Actions
-*.* :omstdout:             # send everything to stdout
+*.* :omstdout:;msgOnlyFormat           # send everything to stdout
 
 # Log anything (except mail) of level info or higher.
 # Don't log private authentication messages!

--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -18,6 +18,8 @@ $WorkDirectory /var/lib/rsyslog
 $template msgOnlyFormat,"%msg%\n"
 $ActionFileDefaultTemplate msgOnlyFormat
 
+$ActionForwardDefaultTemplate msgOnlyFormat
+
 
 # Include all config files in /etc/rsyslog.d/
 $IncludeConfig /etc/rsyslog.d/*.conf


### PR DESCRIPTION
* We need to truncate the non-essential details while capturing the logs originating from `rsyslog` channel. 
* The `msgOnlyFormat` will spew only the `msg` part of the logs on the stdout.
* These logs will go via the usual channel via fluentd to elk backend. 