### PR TITLE
Increase message payload [DO NOT MERGE]

### DIFF
--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -1,4 +1,4 @@
-$MaxMessageSize 64k        # maximum supported message size, must be < UDP datagram
+$MaxMessageSize 64k        # maximum supported message size
 $ModLoad omstdout.so       # provide messages to stdout
 
 # Provides UDP syslog reception

--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -1,3 +1,4 @@
+$MaxMessageSize 64k        # maximum supported message size, must be < UDP datagram
 $ModLoad omstdout.so       # provide messages to stdout
 
 # Provides UDP syslog reception


### PR DESCRIPTION
* `rsyslog` default log string size limitation is 1024 characters per line logged. Some of the messages are getting truncated in the router logs. 
* More at https://www.rsyslog.com/doc/v8-stable/configuration/global/index.html